### PR TITLE
refactor(client/server): Exploit fixes. (read desc)

### DIFF
--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -62,10 +62,8 @@ AddEventHandler('az-trailer:return', function()
 end)
 
 AddEventHandler('az-trailer:spawncar', function(model)
-    local success = lib.callback.await('az_trailer:server:attemptRental', false, model)
-    if not success then
-        QBCore.Functions.Notify('You do not have a current rental out.', 'error')
-    end
+    if not model then return end
+    lib.callback.await('az_trailer:server:attemptRental', false, model)
 end)
 
 AddEventHandler('az-trailer:openMenu', function()

--- a/config.lua
+++ b/config.lua
@@ -1,63 +1,43 @@
-Config = {}
+QBCore = exports['qb-core']:GetCoreObject()
 
--- Menu
-Config.Menu = 'ox' -- use 'ox' for ox_lib menu and 'qb' for qb-menu
+return {
+    Menu = 'ox', -- use 'ox' for ox_lib menu and 'qb' for qb-menu
+    PedLocation = vec4(-58.62, -1691.88, 28.48, 300),
+    PedModel = 'S_F_M_Autoshop_01',
+    PedScenario = 'WORLD_HUMAN_STAND_IMPATIENT_UPRIGHT_FACILITY',
+    BlipName = 'Trailer Rental',
+    BlipSprite = 479, -- trailer sprite
+    BlipScale = 0.8,
+    BlipColour = 0, -- white
+    VehicleCanTrail = {
+        {name = 'GUARDIAN',     class = {8}},
+        {name = 'SQUADDIE',     class = {8}},
+        {name = 'BENSON',       class = {8}},
+        {name = 'EVERON',       class = {8}},
+        {name = 'TITAN',        class = {8}},
+        {name = 'SANDKING',     class = {8}},
+        {name = 'SANDKING2',     class = {8}},
+        {name = 'DUBSTA3',      class = {8}},
+        {name = 'BOBCATXL',     class = {8}},
+        {name = 'BOATTRAILER',  class = {14}},
+        {name = 'WASTLNDR',     class = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}},
+        {name = 'TRAILER',      class = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}}
+    },
+    Lang = {
+        ["TrailerNotFound"] =    'Trailer not found',
+        ["RampAlreadySet"] =   'A ramp is already attached',
+        ["NoVehicleSet"] =      'No vehicle attached found',
+        ["CantSetThisType"] =   'You cannot attach this type of vehicle to this trailer',
+        ["NotInVehicle"] =      'You are not in a vehicle',
+    },
+    Command = {
+        ["attachtrailer"] = "attach",
+        ["detachtrailer"] = "detach",
 
--- Prices
-Config.RefundPrice = 150 -- default refund amount
-Config.TrailersmallPrice = 250
-Config.BoattrailerPrice = 250
---Config.TracktrailerPrice = 7500
-
--- Trailer Ped
-Config.PedLocation = vector4(-58.62, -1691.88, 28.48, 300)
-Config.PedModel = 'S_F_M_Autoshop_01'
-Config.PedScenario = 'WORLD_HUMAN_STAND_IMPATIENT_UPRIGHT_FACILITY'
-
--- Blip
-Config.BlipName = 'Trailer Rental'
-Config.BlipSprite = 479 -- trailer sprite
-Config.BlipScale = 0.8
-Config.BlipColour = 0 -- white
-
--- Trailers
-Config.TrailersmallSpawnLocation = vector4(-48.56, -1692.29, 30, 280) -- right of ped
-Config.BoattrailerSpawnLocation = vector4(-57.40, -1685.42, 29.49, 300) -- left of ped
----Config.TracktrailerSpawnLocation = vector4(-29.00, -1680.40, 29.45, 117.05) -- infront of big garage door
-
--- Set which vehicles can attach a trailer
-Config.VehicleCanTrail = {
-    {name = 'GUARDIAN',     class = {8}},
-    {name = 'SQUADDIE',     class = {8}},
-    {name = 'BENSON',       class = {8}},
-    {name = 'EVERON',       class = {8}},
-    {name = 'TITAN',        class = {8}},
-    {name = 'SANDKING',     class = {8}},
-    {name = 'SANDKING2',     class = {8}},
-    {name = 'DUBSTA3',      class = {8}},
-    {name = 'BOBCATXL',     class = {8}},
-    {name = 'BOATTRAILER',  class = {14}},
-    {name = 'WASTLNDR',     class = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}},
-    {name = 'TRAILER',      class = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}}
-}
-
--- General Locale
-Config.Lang = {
-    ["TrailerNotFound"] =    'Trailer not found',
-    ["RampAlreadySet"] =   'A ramp is already attached',
-    ["NoVehicleSet"] =      'No vehicle attached found',
-    ["CantSetThisType"] =   'You cannot attach this type of vehicle to this trailer',
-    ["NotInVehicle"] =      'You are not in a vehicle',
-}
-
--- Command Locale
-Config.Command = {
-    ["attachtrailer"] = "attach",
-    ["detachtrailer"] = "detach",
-
-    -- TR2 TRAILER
-    ["openramptr2"] = "openramptr2",
-    ["opentrunktr2"] = "opentrunktr2",
-    ["closeramptr2"] = "closeramptr2",
-    ["closetrunktr2"] = "closetrunktr2",
+        -- TR2 TRAILER
+        ["openramptr2"] = "openramptr2",
+        ["opentrunktr2"] = "opentrunktr2",
+        ["closeramptr2"] = "closeramptr2",
+        ["closetrunktr2"] = "closetrunktr2",
+    },
 }

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,25 +4,17 @@ games { 'gta5' }
 description 'Az_trailer by Azeroth - edited by MadCap'
 version '3.0'
 
+shared_scripts {
+    '@ox_lib/init.lua',
+    'config.lua',
+}
+
 client_scripts {
-	'config.lua',
     'client/**/*.lua',
 }
 
-shared_scripts {
-    '@ox_lib/init.lua'
-}
-
 server_scripts {
-	'@mysql-async/lib/MySQL.lua',
-	'config.lua',
     'server/**/*.lua',
-}
-
-dependencies {
-	'qb-core',
-	'qb-target',
-	'qb-menu',
 }
 
 lua54 'yes'

--- a/server/server.lua
+++ b/server/server.lua
@@ -1,15 +1,90 @@
-QBCore = exports['qb-core']:GetCoreObject()
+local cachePlayers = {}
+local Server = {
+    RefundPrice = 150,
+    Rentals = {
+        trailersmall = {price = 250, spawn = vec4(-48.56, -1692.29, 30, 280)},
+        boattrailer = {price = 250, spawn = vec4(-57.40, -1685.42, 29.49, 300)},
+    },
+}
 
-RegisterServerEvent('az_trailer:TakeCash')
-AddEventHandler('az_trailer:TakeCash', function(money)
+local function createTrailer(source, model, coords)
+    local veh = CreateVehicle(joaat(model), coords.x, coords.y, coords.z, coords.w, true, true)
+    local ped = GetPlayerPed(source)
+
+    while not DoesEntityExist(veh) do Wait(0) end 
+
+    return veh
+end
+
+lib.callback.register('az_trailer:server:attemptRental', function(source, model)
+    if cachePlayers[source] then
+        QBCore.Functions.Notify(source, 'You already have a rental.', 'error')
+        return false 
+    end
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-    Player.Functions.RemoveMoney('cash', money, "Trailer Rental")
+    local balance = Player.PlayerData.money.cash
+    if Server.Rentals[model] and balance >= Server.Rentals[model].price then
+        Player.Functions.RemoveMoney('cash', Server.Rentals[model].price, 'Trailer Rental')
+        local coords = Server.Rentals[model].spawn or vec4(-49.96, -1692.76, 29.49, 287.79)
+        local vehicle = createTrailer(src, model, coords)
+        cachePlayers[src] = {}
+        cachePlayers[src].entity = vehicle
+        return true, NetworkGetNetworkIdFromEntity(vehicle)
+    else
+        QBCore.Functions.Notify(source, ('You need $%s in cash to rent this trailer'):format(Server.Rentals[model].price), 'error')
+        return false
+    end
 end)
 
-RegisterServerEvent('az_trailer:GiveRefund')
-AddEventHandler('az_trailer:GiveRefund', function(money)
+lib.callback.register('az_trailer:server:returnRental', function(source)
+    if not cachePlayers[source] then return false end
+
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-    Player.Functions.AddMoney('cash', money, "Trailer Rental")
+
+    if cachePlayers[src].entity and DoesEntityExist(cachePlayers[src].entity) then
+        DeleteEntity(cachePlayers[src].entity)
+        Player.Functions.AddMoney('cash', Server.RefundPrice, 'Returned Trailer')
+        QBCore.Functions.Notify(source, ('You received $%s for returning the trailer.'):format(Server.RefundPrice))
+    else
+        QBCore.Functions.Notify(source, 'Your trailer could not be found and returned. You were not refunded.', 'error')
+    end
+
+    cachePlayers[src] = nil
+    return true
+end)
+
+AddEventHandler('onResourceStart', function(resource)
+    if GetCurrentResourceName() == resource then
+        SetTimeout(2000, function()
+            TriggerClientEvent('az_trailer:cacheConfig', -1, Server)
+        end)
+    end
+end)
+
+RegisterNetEvent('QBCore:Server:OnPlayerLoaded', function()
+    SetTimeout(2000, function()
+        TriggerClientEvent('az_trailer:cacheConfig', source, Server)
+    end)
+end)
+
+RegisterNetEvent('QBCore:Server:OnPlayerUnload', function(source)
+    local src = source
+    if cachePlayers[src] then
+        if cachePlayers[src].entity and DoesEntityExist(cachePlayers[src].entity) then
+            DeleteEntity(cachePlayers[src].entity)
+        end
+        cachePlayers[src] = nil
+    end
+end)
+
+AddEventHandler('playerDropped', function()
+    local src = source
+    if cachePlayers[src] then
+        if cachePlayers[src].entity and DoesEntityExist(cachePlayers[src].entity) then
+            DeleteEntity(cachePlayers[src].entity)
+        end
+        cachePlayers[src] = nil
+    end
 end)

--- a/server/server.lua
+++ b/server/server.lua
@@ -26,6 +26,7 @@ lib.callback.register('az_trailer:server:attemptRental', function(source, model)
     local balance = Player.PlayerData.money.cash
     if Server.Rentals[model] and balance >= Server.Rentals[model].price then
         Player.Functions.RemoveMoney('cash', Server.Rentals[model].price, 'Trailer Rental')
+        QBCore.Functions.Notify(source, ('You paid $%s for a rental.'):format(Server.Rentals[model].price), 'success')
         local coords = Server.Rentals[model].spawn or vec4(-49.96, -1692.76, 29.49, 287.79)
         local vehicle = createTrailer(src, model, coords)
         cachePlayers[src] = {}


### PR DESCRIPTION
- Fixed all exploitable money events and replaced with callbacks and security. 
- Vehicles are now spawned server side and so is the pricing and models. They get sent to the client when the player loads in/resource gets restarted. 
- Made a cache table for players on server side to store the spawned trailer so it can easily be deleted when returning/player leaves the server. 
- If the trailer doesn't exist when returning, the player will not be refunded. 
- Converted Config to use lib.require.
- Minor clean up and rewrite on client related to choosing a rental and added a target entity to the ped.

I did NOT touch the functionality of the script (attaching/detaching/ramps) etc. That part is untested.